### PR TITLE
добавить иконку Bullet для списков и хлебных крошек

### DIFF
--- a/src/UI-KIT/Icons/IconBullet.js
+++ b/src/UI-KIT/Icons/IconBullet.js
@@ -1,0 +1,27 @@
+import PropTypes from "prop-types";
+
+export default function IconBullet({ size, color, extClassName }) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      className={extClassName}
+    >
+      <circle cx="12" cy="12" r="2" fill={color} />
+    </svg>
+  );
+}
+
+IconBullet.propTypes = {
+  size: PropTypes.oneOf(["24", "32", "60"]),
+  color: PropTypes.string.isRequired,
+  extClassName: PropTypes.string,
+};
+
+IconBullet.defaultProps = {
+  size: "32",
+  extClassName: null,
+};

--- a/src/UI-KIT/Icons/IconBullet.js
+++ b/src/UI-KIT/Icons/IconBullet.js
@@ -22,6 +22,6 @@ IconBullet.propTypes = {
 };
 
 IconBullet.defaultProps = {
-  size: "32",
+  size: "24",
   extClassName: null,
 };

--- a/src/UI-KIT/Icons/index.js
+++ b/src/UI-KIT/Icons/index.js
@@ -2,12 +2,21 @@ import { useMemo } from "react";
 
 import IconAccount from "./IconAccount";
 import IconArrow from "./IconArrow";
+import IconBullet from "./IconBullet";
 import IconOctopusArrow from "./IconOctopusArrow";
 import IconPin from "./IconPin";
 import IconRound from "./IconRound";
 import IconSearch from "./IconSearch";
 
-const icons = { IconAccount, IconArrow, IconOctopusArrow, IconPin, IconRound, IconSearch };
+const icons = {
+  IconAccount,
+  IconArrow,
+  IconBullet,
+  IconOctopusArrow,
+  IconPin,
+  IconRound,
+  IconSearch,
+};
 
 export default function Icon({ icon, ...props }) {
   const RenderIcon = useMemo(() => icons[icon], [icon]);

--- a/src/UI-KIT/Icons/index.stories.jsx
+++ b/src/UI-KIT/Icons/index.stories.jsx
@@ -14,11 +14,12 @@ const meta = {
   argTypes: {
     icon: {
       description:
-        "Обязательный параметр объявления используемой иконки. Может принимать значения - IconAccount | IconArrow | IconOctopusArrow | IconPin | IconRound | IconSearch",
+        "Обязательный параметр объявления используемой иконки. Может принимать значения - IconAccount | IconArrow | IconBullet | IconOctopusArrow | IconPin | IconRound | IconSearch",
       control: { type: "select" },
       options: [
         "IconAccount",
         "IconArrow",
+        "IconBullet",
         "IconOctopusArrow",
         "IconPin",
         "IconRound",
@@ -27,7 +28,7 @@ const meta = {
     },
     size: {
       description:
-        "Необязательный параметр размера иконки. По умолчанию задан стандартный размер 32px, кроме иконки OctopusArrow у которой стандартный размер 60px. Может принимать значения - 24 | 32 | 60",
+        "Необязательный параметр размера иконки. По умолчанию стандартный размер 32px, кроме: иконки Bullet у который стандартный размер 24px и иконки OctopusArrow у которой стандартный размер 60px. Может принимать значения - 24 | 32 | 60",
       control: { type: "inline-radio" },
       options: ["24", "32", "60"],
     },
@@ -61,6 +62,16 @@ export const IconArrow = {
   args: {
     icon: "IconArrow",
     size: 32,
+    color: "black",
+    extClassName: "forStory",
+    direction: "up",
+  },
+};
+
+export const IconBullet = {
+  args: {
+    icon: "IconBullet",
+    size: 24,
     color: "black",
     extClassName: "forStory",
     direction: "up",


### PR DESCRIPTION
по итогу решил сделать иконку. 
- решение через ::after создаст проблемы при резиновой верстке, т.к встает не между элементами, а прям в элемент
- решение через стандартный list-type плохо настраиваемое во первых кружоче похож но не 1в1 и да можно вставить свое изображение, но во вторых отступы все будут из кривых цифр, т.к выравнивание идет от правой части кружка и его не учитвают элементы слева сложно у него абсолютное позиционирование. и в третих и наверное в основном, при наведении на кружок будет ховер над элементом, что не нужно
- решение с иконкой тоже не нравится, т.к. приходится непосредственно в верстку добавлять эту иконку, но выходит самый ровный вариант 