### PR TITLE
Скорректировать стили компонента инпут

### DIFF
--- a/src/UI-KIT/Button/Button.scss
+++ b/src/UI-KIT/Button/Button.scss
@@ -19,7 +19,7 @@
 
   &_style_fill {
     @include roboto-16($white);
-    
+
     background: $gradient-blue;
 
     &::before {

--- a/src/UI-KIT/Input/Input.jsx
+++ b/src/UI-KIT/Input/Input.jsx
@@ -25,30 +25,41 @@ function Input({
     return icon ? "input__field_icon" : "";
   }
 
-  function hideExraParams() {
-    return onlyInput ? "input__hide" : "";
-  }
+  const inputField = (
+    <input
+      type={type}
+      name={name}
+      id={id}
+      className={`input__field ${errorStyle()} ${inputWithIconStyle()} ${extClassNameInput}`}
+      required={required}
+      placeholder={placeholder}
+      onChange={onChange}
+      value={value}
+      {...props}
+    />
+  );
+
+  const inputIcon = <div className="input__field-icon">{icon}</div>;
 
   return (
     <div className="input">
-      <label className={`input__label ${extClassNameLabel} ${hideExraParams()}`} htmlFor={id}>
-        {label}
-      </label>
-      <div className="input__container">
-        <div className="input__field-icon">{icon}</div>
-        <input
-          type={type}
-          name={name}
-          id={id}
-          className={`input__field ${errorStyle()} ${inputWithIconStyle()} ${extClassNameInput}`}
-          required={required}
-          placeholder={placeholder}
-          onChange={onChange}
-          value={value}
-          {...props}
-        />
-      </div>
-      <span className={`input__error-text ${hideExraParams()}`}>{error}</span>
+      {onlyInput ? (
+        <>
+          {inputIcon}
+          {inputField}
+        </>
+      ) : (
+        <>
+          <label className={`input__label ${extClassNameLabel}`} htmlFor={id}>
+            {label}
+          </label>
+          <div className="input__container">
+            {inputIcon}
+            {inputField}
+          </div>
+          <span className="input__error-text">{error}</span>
+        </>
+      )}
     </div>
   );
 }

--- a/src/UI-KIT/Input/Input.scss
+++ b/src/UI-KIT/Input/Input.scss
@@ -1,7 +1,10 @@
 @import "/src/assets/style/main";
 
 .input {
-  @include flex(start, flex-start, column);
+  @include flex(start, center, column);
+
+  width: 100%;
+  position: relative;
 }
 
 .input__container {
@@ -22,7 +25,7 @@
 .input__field {
   width: inherit;
   padding: 12px;
-  background-color: transparent;
+  background-color: $white;
   border: 1px solid $blue;
   border-radius: 10px;
   font-size: $text-size-default;
@@ -47,7 +50,7 @@
 
 .input__field-icon {
   position: absolute;
-  height: 50%;
+  max-height: 24px;
   left: 20px;
 }
 
@@ -61,8 +64,4 @@
   font-size: 16px;
   font-weight: 300;
   line-height: 22.4px;
-}
-
-.input__hide {
-  display: none;
 }

--- a/src/components/Search/Search.jsx
+++ b/src/components/Search/Search.jsx
@@ -2,11 +2,11 @@ import React from "react";
 // import PropTypes from "prop-types";
 import { Link } from "react-router-dom";
 
-import "./Search.scss";
-
 import Input from "UI-KIT/Input/Input";
 import { Button } from "UI-KIT/Button/Button";
 import Icon from "UI-KIT/Icons";
+
+import "./Search.scss";
 
 export function Search() {
   const [isButtonDisabled, setIsButtonDisabled] = React.useState(true);
@@ -73,6 +73,7 @@ export function Search() {
         required="false"
         placeholder="Название компании или услуга"
         onChange={() => console.log("изменение инпута name")}
+        onlyInput
       />
       <Input
         icon={<Icon icon="IconPin" color="#4e4cbf" size="24" />}
@@ -83,6 +84,7 @@ export function Search() {
         required="false"
         placeholder="Город"
         onChange={() => console.log("изменение инпута city")}
+        onlyInput
       />
       <Button
         extClassName="search__input-button"

--- a/src/components/Search/Search.scss
+++ b/src/components/Search/Search.scss
@@ -9,7 +9,7 @@
   }
 
   &__input {
-    padding: 20px;
+    padding: 20px 20px 20px 56px;
   }
 
   &__input-label {


### PR DESCRIPTION
Переписал компонент инпута - теперь при необходимости вывести только инпут будет чистый код без лишнего мусора
Добавил центрирование иконок (в соответствии со сторибуком максимальный размер иконки 24px)

В части компонента поиска в jsx подключил стиль после инпута для корректной работы, добавил параметр onlyInput к обоим импутам; в css скорректировал padding инпута